### PR TITLE
Avoid zero-size struct compiler warning

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,8 +14,7 @@ pub const RTLSDR_TUNER_R820T: c_int = 5;
 pub const RTLSDR_TUNER_R828D: c_int = 6;
 
 #[allow(non_camel_case_types)]
-#[repr(C)]
-pub struct rtlsdr_dev;
+pub enum rtlsdr_dev {}
 
 #[link(name="rtlsdr")]
 extern "C" {


### PR DESCRIPTION
New rust compiler (I use 1.8) is not happy about empty structure. Documentation suggests using empty enum for opaque C structs.

Address "found zero-size struct in foreign module, consider adding a member to this struct, #[warn(improper_ctypes)] on by default" warning by using empty enum, as recommended for opaque structures by documentation: https://doc.rust-lang.org/book/ffi.html#representing-opaque-structs
