### PR TITLE
Fix SIGTRAP on exit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub fn get_index_by_serial(serial: String) -> Result<i32, RTLSDRError> {
 /// Returns a Result on an RTLSDRDevice object which exposes further
 /// methods.
 pub fn open(index: i32) -> Result<RTLSDRDevice, RTLSDRError> {
-    let mut device: RTLSDRDevice = unsafe { std::mem::zeroed() };
+    let mut device: RTLSDRDevice = RTLSDRDevice { ptr: std::ptr::null_mut() };
     let idx = index as libc::uint32_t;
     match unsafe { ffi::rtlsdr_open(&mut device.ptr, idx) } {
         0 => Ok(device),


### PR DESCRIPTION
Once device is open, I'm getting "`target/debug/rtlsdr_demo` (signal: 5, SIGTRAP: trace/breakpoint trap)" on process  exit.
It seems to be bad idea to initialize rust struct with mem::zeroed. Instead assign null pointer to raw pointer field. One less "unsafe" block is also a good thing.
